### PR TITLE
Include properties with geojson, ensure FeatureCollection

### DIFF
--- a/mapit/geometryserialiser.py
+++ b/mapit/geometryserialiser.py
@@ -135,7 +135,7 @@ class GeometrySerialiser:
     def area_as_geojson_feature(self, area, polygons):
         return {
             'type': 'Feature',
-            'properties': area.as_dict(),
+            'properties': {'name': area.name},
             'geometry': json.loads(polygons.json),
         }
 

--- a/mapit/geometryserialiser.py
+++ b/mapit/geometryserialiser.py
@@ -1,3 +1,5 @@
+import json
+
 from django.contrib.gis.gdal import SRSException, OGRException
 from django.conf import settings
 from django.utils.html import escape
@@ -37,6 +39,14 @@ class GeometrySerialiser:
 </kml>"""
 
     def __init__(self, areas, srid, simplify_tolerance):
+        # the geojson serialization format needs to know if we're
+        # serializer one item, or a list with one item
+        if not isinstance(areas, list):
+            self.single = True
+            areas = [areas]
+        else:
+            self.single = False
+
         self.areas = areas
         self.srid = srid
         self.simplify_tolerance = simplify_tolerance
@@ -79,7 +89,7 @@ class GeometrySerialiser:
             if polygons:
                 polygons = self.__transform(polygons)
                 polygons = self.__simplify(polygons, area.name)
-                processed_areas.append((polygons, area.name))
+                processed_areas.append((polygons, area))
         if len(processed_areas) == 0:
             raise TransformError("No polygons found")
         else:
@@ -94,7 +104,7 @@ class GeometrySerialiser:
         if kml_type == "full":
             output = self.kml_header % (line_colour, fill_colour)
             for area in processed_areas:
-                output += self.kml_placemark % (escape(area[1]), area[0].kml)
+                output += self.kml_placemark % (escape(area[1].name), area[0].kml)
             output += self.kml_footer
             return (output, content_type)
         elif kml_type == "polygon":
@@ -110,16 +120,24 @@ class GeometrySerialiser:
     def geojson(self):
         content_type = 'application/json'
         processed_areas = self.__process_polygons()
-        if len(processed_areas) == 1:
+        if len(processed_areas) == 1 and self.single:
             return (processed_areas[0][0].json, content_type)
         else:
-            output = '{ "type": "FeatureCollection", "features": ['
-            for area in processed_areas:
-                output += '{ "properties": { "name": "%s" }, "type": "Feature", "geometry": %s },'\
-                    % (escape(area[1]), area[0].json)
-            output = output[:-1]
-            output += "] }"
-            return (output, content_type)
+            output = {
+                'type': 'FeatureCollection',
+                'features': [
+                    self.area_as_geojson_feature(area[1], area[0])
+                    for area in processed_areas
+                ]
+            }
+            return (json.dumps(output), content_type)
+
+    def area_as_geojson_feature(self, area, polygons):
+        return {
+            'type': 'Feature',
+            'properties': area.as_dict(),
+            'geometry': json.loads(polygons.json),
+        }
 
     # output self.areas as wkt
     def wkt(self):

--- a/mapit/models.py
+++ b/mapit/models.py
@@ -316,8 +316,7 @@ class Area(models.Model):
         all_polygons = self.polygons.all()
         if len(all_polygons) == 0:
             return (None, None)
-        areas = [self]
-        serialiser = GeometrySerialiser(areas, srid, simplify_tolerance)
+        serialiser = GeometrySerialiser(self, srid, simplify_tolerance)
         if export_format == 'kml':
             out, content_type = serialiser.kml(kml_type, line_colour, fill_colour)
         elif export_format in ('json', 'geojson'):

--- a/mapit/tests/test_views.py
+++ b/mapit/tests/test_views.py
@@ -117,17 +117,12 @@ class AreaViewsTest(TestCase):
     def test_areas_polygon_one_id(self):
         id = self.small_area_1.id
 
-        url_area  = '/area/%d.geojson' % id
-        response_area = self.client.get(url_area)
-        self.assertEqual(response_area.status_code, 200)
-        content_area = json.loads(response_area.content.decode('utf-8'))
-
         url_areas = '/areas/%d.geojson' % id
         response_areas = self.client.get(url_areas)
         self.assertEqual(response_areas.status_code, 200)
         content_areas = json.loads(response_areas.content.decode('utf-8'))
 
-        self.assertEqual(content_area, content_areas)
+        self.assertEqual(content_areas['type'], 'FeatureCollection')
 
     def test_areas_polygon_bad_params(self):
         url = '/areas/99999.geojson'

--- a/mapit/views/areas.py
+++ b/mapit/views/areas.py
@@ -272,7 +272,7 @@ def areas_polygon(request, area_ids, srid='', format='kml'):
         if not re.match('\d+$', area_id):
             raise ViewException(format, _('Bad area ID specified'), 400)
 
-    areas = Area.objects.filter(id__in=area_ids)
+    areas = list(Area.objects.filter(id__in=area_ids))
     if not areas:
         return output_json({'error': _('No areas found')}, code=404)
 


### PR DESCRIPTION
This pulls in an area's properties into the geojson
so that they don't also need to call .json for each area.

This also ensures that /areas/1.geojson always returns a
FeatureCollection, which means the caller/client isn't surprised that
sometimes the response is a polygon, and sometimes it's a feature
collection.  They always knows what type of object is going to come back
and can act accordingly. If they know they only want a single item, they
can use /area/1.geojson.
